### PR TITLE
surya: Don't make init permissive

### DIFF
--- a/sepolicy/private/init.te
+++ b/sepolicy/private/init.te
@@ -1,5 +1,3 @@
-permissive init;
-
 # vendor_overlay
 allow init vendor_configs_file:dir mounton;
 allow init vendor_overlay_file:dir mounton;


### PR DESCRIPTION
 * This is not allowed in AOSP sepolicy, and for devices with Magisk
   installed, it will force restorecon context of /data/adb, which was
   been changed to system_file by Magisk on purpose, and break a lot
   of modules in the end.